### PR TITLE
Update image reference to Git SHA

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: royvishu1224/plot-test
-  newTag: 1ac799a
+  newTag: deb125b
 
 resources:
 - service.yaml


### PR DESCRIPTION
This pull request updates the image reference in the Kustomization file to the Git SHA: deb125b