### PR TITLE
Update image reference to Git SHA

### DIFF
--- a/dev/kustomization.yaml
+++ b/dev/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: default
 
 images:
 - name: royvishu1224/plot-test
-  newTag: 2b49c6c
+  newTag: c38c740
 
 
 patchesStrategicMerge:


### PR DESCRIPTION
This pull request updates the image reference in the Kustomization file to the Git SHA: c38c740