### PR TITLE
Update image reference to Git SHA

### DIFF
--- a/dev/kustomization.yaml
+++ b/dev/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: default
 
 images:
 - name: royvishu1224/plot-test
-  newTag: ab30f37
+  newTag: 3300f8a
 
 
 patchesStrategicMerge:


### PR DESCRIPTION
This pull request updates the image reference in the Kustomization file to the Git SHA: 3300f8a